### PR TITLE
Tweaks

### DIFF
--- a/src/plugins/kibana/public/settings/sections/indices/_indexed_fields.js
+++ b/src/plugins/kibana/public/settings/sections/indices/_indexed_fields.js
@@ -24,7 +24,7 @@ define(function (require) {
           { title: 'format' },
           { title: 'analyzed', info: 'Analyzed fields may require extra memory to visualize' },
           { title: 'indexed', info: 'Fields that are not indexed are unavailable for search' },
-          { title: 'exclude', info: 'Fields that are not excluded from _source when _source is fetched' },
+          { title: 'exclude', info: 'Fields that are excluded from _source when it is fetched' },
           { title: 'controls', sortable: false }
         ];
 

--- a/src/plugins/kibana/public/settings/sections/indices/_indexed_fields.js
+++ b/src/plugins/kibana/public/settings/sections/indices/_indexed_fields.js
@@ -34,13 +34,11 @@ define(function (require) {
           // clear and destroy row scopes
           _.invoke(rowScopes.splice(0), '$destroy');
 
-          const metaFields = config.get('metaFields');
           var fields = filter($scope.indexPattern.getNonScriptedFields(), $scope.fieldFilter);
           _.find($scope.fieldTypes, {index: 'indexedFields'}).count = fields.length; // Update the tab count
 
           $scope.rows = fields.map(function (field) {
             var childScope = _.assign($scope.$new(), { field: field });
-            const isMetaField = _.contains(metaFields, field.name);
             rowScopes.push(childScope);
 
             return [
@@ -64,8 +62,8 @@ define(function (require) {
                 value: field.indexed
               },
               {
-                markup: isMetaField || !!field.exclude ? noTemplate : yesTemplate,
-                value: isMetaField || !!field.exclude
+                markup: !field.exclude ? yesTemplate : noTemplate,
+                value: !field.exclude
               },
               {
                 markup: controlsHtml,

--- a/src/plugins/kibana/public/settings/sections/indices/_indexed_fields.js
+++ b/src/plugins/kibana/public/settings/sections/indices/_indexed_fields.js
@@ -24,7 +24,7 @@ define(function (require) {
           { title: 'format' },
           { title: 'analyzed', info: 'Analyzed fields may require extra memory to visualize' },
           { title: 'indexed', info: 'Fields that are not indexed are unavailable for search' },
-          { title: 'retrieved', info: 'Fields that are not retrieved as part of the _source object per hit' },
+          { title: 'exclude', info: 'Fields that are not excluded from _source when _source is fetched' },
           { title: 'controls', sortable: false }
         ];
 
@@ -62,8 +62,8 @@ define(function (require) {
                 value: field.indexed
               },
               {
-                markup: !field.exclude ? yesTemplate : noTemplate,
-                value: !field.exclude
+                markup: field.exclude ? yesTemplate : noTemplate,
+                value: field.exclude
               },
               {
                 markup: controlsHtml,

--- a/src/ui/public/field_editor/field_editor.html
+++ b/src/ui/public/field_editor/field_editor.html
@@ -106,12 +106,8 @@
       </h4>
 
       <p>
-      If checked, this field will not be retrieved as part of the <b>_source</b> object. This is thanks to the
-      <a target="_window" href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html">
-        source filtering API
-        <i aria-hidden="true" class="fa-link fa"></i>
-      </a>
-      of Elasticsearch.
+      If checked, this field will be filtered from the <b>_source</b> of each document using
+      <a target="_window" href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html">source filtering<i aria-hidden="true" class="fa-link fa"></i></a>. This only impacts views that fetch the _source for documents, like Discover or the doc table.
       </p>
       <p>
       If this field is explicitly selected in your saved search, then it will not be excluded.

--- a/src/ui/public/index_patterns/_field.js
+++ b/src/ui/public/index_patterns/_field.js
@@ -1,5 +1,5 @@
 define(function (require) {
-  return function FieldObjectProvider(Private, shortDotsFilter, $rootScope, Notifier) {
+  return function FieldObjectProvider(Private, shortDotsFilter, $rootScope, Notifier, config) {
     var notify = new Notifier({ location: 'IndexPattern Field' });
     var FieldFormat = Private(require('ui/index_patterns/_field_format/FieldFormat'));
     var fieldTypes = Private(require('ui/index_patterns/_field_types'));
@@ -41,11 +41,12 @@ define(function (require) {
       var sortable = spec.name === '_score' || ((indexed || scripted) && type.sortable);
       var bucketable = indexed || scripted;
       var filterable = spec.name === '_id' || scripted || (indexed && type.filterable);
+      var isMetaField = config.get('metaFields').includes(spec.name);
 
       obj.fact('name');
       obj.fact('type');
       obj.writ('count', spec.count || 0);
-      obj.writ('exclude', spec.exclude);
+      obj.fact('exclude', Boolean(!isMetaField && spec.exclude));
 
       // scripted objs
       obj.fact('scripted', scripted);

--- a/src/ui/public/index_patterns/_index_pattern.js
+++ b/src/ui/public/index_patterns/_index_pattern.js
@@ -293,8 +293,19 @@ define(function (require) {
       };
 
       self._fetchFields = function () {
+        var existingFieldsByName = self.fields.byName;
+
         return mapper.getFieldsForIndexPattern(self, true)
         .then(function (fields) {
+
+          // copy over kibana-added properties from existing fields
+          fields.forEach(function (field) {
+            var existingField = existingFieldsByName[field.name];
+            if (existingField) {
+              field.exclude = existingField.exclude;
+            }
+          });
+
           // append existing scripted fields
           fields = fields.concat(self.getScriptedFields());
 

--- a/test/functional/apps/settings/_index_pattern_create_delete.js
+++ b/test/functional/apps/settings/_index_pattern_create_delete.js
@@ -53,7 +53,7 @@ define(function (require) {
               'format',
               'analyzed',
               'indexed',
-              'retrieved',
+              'exclude',
               'controls'
             ];
 


### PR DESCRIPTION
I played around with this this branch for a while and made a couple tweaks that I think improve https://github.com/elastic/kibana/pull/5881
1. When refreshing the fields for an index pattern, preserve the excluded setting for existing fields
2. Change the "retrieved" column to show "excluded" fields. This prevents us from implying that we will somehow cause multi_fields to be included in source (like `@message.raw`).
3. Move metaField consideration into the field constructor so that `field.exclude` is accurate
4. touched up the help message for in the field editor
